### PR TITLE
Remove the `StripCTParms()` calls to keep the towgs84 parameter in the spatial references

### DIFF
--- a/buzzard/_datasource_conversions.py
+++ b/buzzard/_datasource_conversions.py
@@ -11,14 +11,8 @@ class DataSourceConversionsMixin(object):
     conversion subroutines"""
 
     def __init__(self, sr_work, sr_implicit, sr_origin, analyse_transformation):
-        if sr_work:
-            sr_work.StripCTParms()
         self._sr_work = sr_work
-        if sr_implicit:
-            sr_implicit.StripCTParms()
         self._sr_implicit = sr_implicit
-        if sr_origin:
-            sr_origin.StripCTParms()
         self._sr_origin = sr_origin
         self._analyse_transformations = bool(analyse_transformation)
 
@@ -39,8 +33,6 @@ class DataSourceConversionsMixin(object):
                 sr_origin = self._sr_implicit
             else:
                 raise ValueError("Missing origin's spatial reference")
-        else:
-            sr_origin.StripCTParms()
 
         to_work = osr.CreateCoordinateTransformation(sr_origin, self._sr_work).TransformPoints
         to_origin = osr.CreateCoordinateTransformation(self._sr_work, sr_origin).TransformPoints

--- a/buzzard/srs/__init__.py
+++ b/buzzard/srs/__init__.py
@@ -38,8 +38,6 @@ def wkt_same(a, b):
         return True
     sra = osr.SpatialReference(a)
     srb = osr.SpatialReference(b)
-    sra.StripCTParms()
-    srb.StripCTParms()
     return bool(sra.IsSame(srb))
 
 def _details_of_file(path):


### PR DESCRIPTION
The proj4 towgs84 parameter can be necessary to transform data between two spatial reference systems that don't share the same ellipsoid (like from WGS84 to IGNF Lambert Zone). The `StripCTParms()` method remove this parameter in an osr spatial reference. So I deleted it from the buzzard code.