### PR TITLE
Proxies flexibility / DataSource pickling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ for poly in ds.polygons.iter_data(None):
 ```
 
 ## Advanced (and fun 😊) examples
-
 Additional examples can be found here: [jupyter notebook](./doc/examples.ipynb).
 
 ## Features
@@ -153,17 +152,18 @@ pytest buzzard/buzzard/test
 ```
 
 ## Documentation
-See code (docstrings). Hosted soon
+Hosted soon, in the meantime
+- look at docstrings in code
+- get familiar with the [public classes](https://github.com/airware/buzzard/wiki/Public-classes)
+- play with the exemples in [examples.ipynb](./doc/examples.ipynb)
 
 ## Contributions and feedback
 Welcome to the `buzzard` project! We appreciate any contribution and feedback, your proposals and pull requests will be considered and responded to. For more information, see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) file.
 
 ## Authors
-
 See [AUTHORS](./AUTHORS.md)
 
 ## License and Notice
-
 See [LICENSE](./LICENSE) and [NOTICE](./NOTICE).
 
 ## Other pages

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -700,6 +700,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
 
         proxies = []
         for prox, keys in self._keys_of_proxy.items():
+
             if prox.picklable:
                 consts = dict(prox._c.__dict__) # Need to recreate dict for cloudpickling
                 proxies.append((

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -484,8 +484,13 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
 
         """
         self._validate_key(key)
-        ogr_ds, lyr = Vector._open_file(path, layer, driver, options, mode)
-        prox = Vector(self, ogr_ds, lyr, mode)
+        gdal_ds, lyr = Vector._open_file(path, layer, driver, options, mode)
+        options = [str(arg) for arg in options]
+        _ = conv.of_of_mode(mode)
+        consts = Vector._Constants(
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode
+        )
+        prox = Vector(self, consts, gdal_ds, lyr)
         self._register([key], prox)
         return prox
 
@@ -494,8 +499,13 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
 
         See DataSource.open_vector
         """
-        ogr_ds, lyr = Vector._open_file(path, layer, driver, options, mode)
-        prox = Vector(self, ogr_ds, lyr, mode)
+        gdal_ds, lyr = Vector._open_file(path, layer, driver, options, mode)
+        options = [str(arg) for arg in options]
+        _ = conv.of_of_mode(mode)
+        consts = Vector._Constants(
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode
+        )
+        prox = Vector(self, consts, gdal_ds, lyr)
         self._register([], prox)
         return prox
 
@@ -573,10 +583,14 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
 
         """
         self._validate_key(key)
-        ogr_ds, lyr = Vector._create_file(
+        gdal_ds, lyr = Vector._create_file(
             path, geometry, fields, layer, driver, options, sr
         )
-        prox = Vector(self, ogr_ds, lyr, 'w')
+        options = [str(arg) for arg in options]
+        consts = Vector._Constants(
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w',
+        )
+        prox = Vector(self, consts, gdal_ds, lyr)
         self._register([key], prox)
         return prox
 
@@ -586,10 +600,14 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
 
         See DataSource.create_vector
         """
-        ogr_ds, lyr = Vector._create_file(
+        gdal_ds, lyr = Vector._create_file(
             path, geometry, fields, layer, driver, options, sr
         )
-        prox = Vector(self, ogr_ds, lyr, 'w')
+        options = [str(arg) for arg in options]
+        consts = Vector._Constants(
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w',
+        )
+        prox = Vector(self, consts, gdal_ds, lyr)
         self._register([], prox)
         return prox
 

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -430,7 +430,10 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
             raise TypeError('fn should be a callable or a sequence of callables')
 
         gdal_ds = RasterRecipe._create_vrt(fp, dtype, len(fn_lst), band_schema, sr)
-        prox = RasterRecipe(self, gdal_ds, fn_lst)
+        consts = RasterRecipe._Constants(
+            self, gdal_ds=gdal_ds, fn_list=fn_lst,
+        )
+        prox = RasterRecipe(self, consts, gdal_ds)
         self._register([key], prox)
         return prox
 
@@ -455,7 +458,10 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
             raise TypeError('fn should be a callable or a sequence of callables')
 
         gdal_ds = RasterRecipe._create_vrt(fp, dtype, len(fn_lst), band_schema, sr)
-        prox = RasterRecipe(self, gdal_ds, fn_lst)
+        consts = RasterRecipe._Constants(
+            self, gdal_ds=gdal_ds, fn_list=fn_lst,
+        )
+        prox = RasterRecipe(self, consts, gdal_ds)
         self._register([], prox)
         return prox
 

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -295,7 +295,9 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         return prox
 
     def create_recipe_raster(self, key, fn, fp, dtype, band_schema=None, sr=None):
-        """Create a raster recipe and register it under `key` in this DataSource.
+        """Experimental feature!
+
+        Create a raster recipe and register it under `key` in this DataSource.
 
         A recipe is a read-only raster that behaves like any other raster, pixel values are computed
         on-the-fly with calls to the provided `pixel functions`. A pixel function maps a Footprint to
@@ -414,7 +416,9 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         return prox
 
     def create_recipe_araster(self, fn, fp, dtype, band_schema=None, sr=None):
-        """Create a raster recipe anonymously in this DataSource.
+        """Experimental feature!
+
+        Create a raster recipe anonymously in this DataSource.
 
         See DataSource.create_recipe_raster
         """

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -662,5 +662,29 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
             return None
         return self._wkt_work
 
+    # Activation mechanisms ********************************************************************* **
+    def activate_all(self):
+        if self._max_activated < len(self._keys_of_proxy):
+            raise RuntimeError("Can't activate all sources at the same time: {} sources and max_activated is {}".format(
+                len(self._keys_of_proxy), self._max_activated,
+            ))
+        for prox in self._keys_of_proxy.keys():
+            if not prox.activated:
+                prox.activate()
+                assert prox.activated
+
+    def deactivate_all(self):
+        """
+        The sources that can't be deactivated (i.e. a raster with the `MEM` driver) are ignored
+        """
+        if self._locked_count != 0:
+            raise RuntimeError("Can't deactivate all sources: some are forced to stay activated (are you iterating on geometries?)")
+        for prox in self._keys_of_proxy.keys():
+            if not prox._c.deactivable:
+                continue
+            if prox.activated:
+                prox.deactivate()
+                assert not prox.activated
+
     # The end *********************************************************************************** **
     # ******************************************************************************************* **

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -11,6 +11,7 @@ from buzzard._proxy import Proxy
 from buzzard._raster_physical import RasterPhysical
 from buzzard._raster_recipe import RasterRecipe
 from buzzard._vector import Vector
+from buzzard._tools import conv
 from buzzard._datasource_conversions import DataSourceConversionsMixin
 
 class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMixin):
@@ -189,7 +190,12 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         """
         self._validate_key(key)
         gdal_ds = RasterPhysical._open_file(path, driver, options, mode)
-        prox = RasterPhysical(self, gdal_ds, mode)
+        options = [str(arg) for arg in options]
+        _ = conv.of_of_mode(mode)
+        consts = RasterPhysical._Constants(
+            self, gdal_ds=gdal_ds, open_options=options, mode=mode
+        )
+        prox = RasterPhysical(self, consts, gdal_ds)
         self._register([key], prox)
         return prox
 
@@ -199,7 +205,12 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         See DataSource.open_raster
         """
         gdal_ds = RasterPhysical._open_file(path, driver, options, mode)
-        prox = RasterPhysical(self, gdal_ds, mode)
+        options = [str(arg) for arg in options]
+        _ = conv.of_of_mode(mode)
+        consts = RasterPhysical._Constants(
+            self, gdal_ds=gdal_ds, open_options=list(options), mode=mode
+        )
+        prox = RasterPhysical(self, consts, gdal_ds)
         self._register([], prox)
         return prox
 
@@ -275,7 +286,11 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         gdal_ds = RasterPhysical._create_file(
             path, fp, dtype, band_count, band_schema, driver, options, sr
         )
-        prox = RasterPhysical(self, gdal_ds, 'w')
+        options = [str(arg) for arg in options]
+        consts = RasterPhysical._Constants(
+            self, gdal_ds=gdal_ds, open_options=options, mode='w'
+        )
+        prox = RasterPhysical(self, consts, gdal_ds)
         self._register([key], prox)
         return prox
 
@@ -290,7 +305,11 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         gdal_ds = RasterPhysical._create_file(
             path, fp, dtype, band_count, band_schema, driver, options, sr
         )
-        prox = RasterPhysical(self, gdal_ds, 'w')
+        options = [str(arg) for arg in options]
+        consts = RasterPhysical._Constants(
+            self, gdal_ds=gdal_ds, open_options=options, mode='w'
+        )
+        prox = RasterPhysical(self, consts, gdal_ds)
         self._register([], prox)
         return prox
 

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -680,7 +680,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         if self._locked_count != 0:
             raise RuntimeError("Can't deactivate all sources: some are forced to stay activated (are you iterating on geometries?)")
         for prox in self._keys_of_proxy.keys():
-            if not prox._c.deactivable:
+            if not prox.deactivable:
                 continue
             if prox.activated:
                 prox.deactivate()

--- a/buzzard/_datasource.py
+++ b/buzzard/_datasource.py
@@ -494,7 +494,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         options = [str(arg) for arg in options]
         _ = conv.of_of_mode(mode)
         consts = Vector._Constants(
-            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode, layer=layer,
         )
         prox = Vector(self, consts, gdal_ds, lyr)
         self._register([key], prox)
@@ -509,7 +509,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         options = [str(arg) for arg in options]
         _ = conv.of_of_mode(mode)
         consts = Vector._Constants(
-            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode=mode, layer=layer,
         )
         prox = Vector(self, consts, gdal_ds, lyr)
         self._register([], prox)
@@ -594,7 +594,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         )
         options = [str(arg) for arg in options]
         consts = Vector._Constants(
-            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w',
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w', layer=layer,
         )
         prox = Vector(self, consts, gdal_ds, lyr)
         self._register([key], prox)
@@ -611,7 +611,7 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         )
         options = [str(arg) for arg in options]
         consts = Vector._Constants(
-            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w',
+            self, gdal_ds=gdal_ds, lyr=lyr, open_options=options, mode='w', layer=layer,
         )
         prox = Vector(self, consts, gdal_ds, lyr)
         self._register([], prox)
@@ -646,3 +646,6 @@ class DataSource(_datasource_tools.DataSourceToolsMixin, DataSourceConversionsMi
         if self._sr_work is None:
             return None
         return self._wkt_work
+
+    # The end *********************************************************************************** **
+    # ******************************************************************************************* **

--- a/buzzard/_datasource_tools.py
+++ b/buzzard/_datasource_tools.py
@@ -91,7 +91,7 @@ class DataSourceToolsMixin(object):
         assert proxy.activated
         if not self._max_activated != np.inf:
             return
-        if not proxy._c.deactivable:
+        if not proxy.deactivable:
             return
         self._ensure_enough_room()
         self._activation_queue[proxy] = 42

--- a/buzzard/_datasource_tools.py
+++ b/buzzard/_datasource_tools.py
@@ -54,28 +54,35 @@ class DataSourceToolsMixin(object):
             assert self._locked_activations[proxy] == 0
             assert not self._activation_queue
         elif case == (False, True, True):
-            assert False, 'lock activated but not activated'
+            assert False, 'lock activated but not activated' # pragma: no cover
         elif case == (False, True, False):
             assert self._locked_activations[proxy] == 0
             assert proxy not in self._activation_queue
         elif case == (False, False, True):
-            assert False, 'lock activated but not activated'
+            assert False, 'lock activated but not activated' # pragma: no cover
         elif case == (False, False, False):
             assert self._locked_activations[proxy] == 0
             assert not self._activation_queue
         else:
-            assert False, 'unreachable'
+            assert False, 'unreachable' # pragma: no cover
 
-    def _activated_count(self):
-        return len(self._locked_activations) + len(self._activation_queue)
+    @property
+    def _queued_count(self):
+        """Used for unit tests"""
+        return len(self._activation_queue)
+
+    @property
+    def _locked_count(self):
+        """Used for unit tests"""
+        return sum(v > 0 for v in self._locked_activations.values())
 
     def _ensure_enough_room(self):
         """Make room in self._activation_queue if necessary"""
-        if len(self._locked_activations) >= self._max_activated:
+        if self._locked_count >= self._max_activated:
             raise RuntimeError(_ERR_FMT.format(
-                self._max_activated, len(self._locked_activations)
+                self._max_activated, self._locked_count
             ))
-        if self._activated_count() >= self._max_activated:
+        if self._locked_count + len(self._activation_queue) >= self._max_activated:
             other_proxy, _ = self._activation_queue.popitem(False)
             other_proxy._deactivate()
 
@@ -160,12 +167,15 @@ class DataSourceToolsMixin(object):
             if self._locked_activations[proxy] == 0:
                 self._activation_queue[proxy] = 42
         elif case == (True, True, False):
-            assert False, 'unlocking but not locked'
+            assert False, 'unlocking but not locked' # pragma: no cover
         elif case == (True, False, True):
             self._locked_activations[proxy] -= 1
-        elif case == (True, False, False):
+        elif case == (True, False, False): # pragma: no cover
             assert False, 'unlocking but not locked'
-        elif case == (False, True, False):
+        elif case == (False, True, False): # pragma: no cover
             assert False, 'unlocking but not locked'
-        elif case == (False, False, False):
+        elif case == (False, False, False): # pragma: no cover
             assert False, 'unlocking but not locked'
+
+    def _is_locked_activate(self, proxy):
+        return self._locked_activations[proxy] > 0

--- a/buzzard/_datasource_tools.py
+++ b/buzzard/_datasource_tools.py
@@ -1,11 +1,25 @@
 """>>> help(DataSourceToolsMixin)"""
 
-class DataSourceToolsMixin(object):
-    """Private mixin for the DataSource class containing subroutines for proxies registration"""
+import collections
 
-    def __init__(self):
+import numpy as np
+
+_ERR_FMT = 'DataSource is configured for a maximum of {} simultaneous activated sources \
+but already {} proxies are requesting to stay activated. (You might be iterating on many \
+vector files at the same time)'
+
+class DataSourceToolsMixin(object):
+    """Private mixin for the DataSource class containing subroutines for proxies:
+    - registration
+    - activation
+    """
+
+    def __init__(self, max_activated):
         self._keys_of_proxy = {}
         self._proxy_of_key = {}
+        self._max_activated = max_activated
+        self._activation_queue = collections.OrderedDict()
+        self._locked_activations = collections.Counter()
 
     def _validate_key(self, key):
         hash(key)
@@ -23,3 +37,135 @@ class DataSourceToolsMixin(object):
             del self.__dict__[key]
             del self._proxy_of_key[key]
         del self._keys_of_proxy[proxy]
+
+    # Activation mechanisms ********************************************************************* **
+    def _assert_states_logic(self, case, proxy):
+        """Assert that a proxy state is valid"""
+        if case == (True, True, True):
+            assert self._locked_activations[proxy] > 0
+            assert proxy not in self._activation_queue
+        elif case == (True, True, False):
+            assert self._locked_activations[proxy] == 0
+            assert proxy in self._activation_queue
+        elif case == (True, False, True):
+            assert self._locked_activations[proxy] > 0
+            assert not self._activation_queue
+        elif case == (True, False, False):
+            assert self._locked_activations[proxy] == 0
+            assert not self._activation_queue
+        elif case == (False, True, True):
+            assert False, 'lock activated but not activated'
+        elif case == (False, True, False):
+            assert self._locked_activations[proxy] == 0
+            assert proxy not in self._activation_queue
+        elif case == (False, False, True):
+            assert False, 'lock activated but not activated'
+        elif case == (False, False, False):
+            assert self._locked_activations[proxy] == 0
+            assert not self._activation_queue
+        else:
+            assert False, 'unreachable'
+
+    def _activated_count(self):
+        return len(self._locked_activations) + len(self._activation_queue)
+
+    def _ensure_enough_room(self):
+        """Make room in self._activation_queue if necessary"""
+        if len(self._locked_activations) >= self._max_activated:
+            raise RuntimeError(_ERR_FMT.format(
+                self._max_activated, len(self._locked_activations)
+            ))
+        if self._activated_count() >= self._max_activated:
+            other_proxy, _ = self._activation_queue.popitem(False)
+            other_proxy._deactivate()
+
+    def _register_new_activated(self, proxy):
+        """Register a proxy that was created in the activated state"""
+        assert proxy.activated
+        if not self._max_activated != np.inf:
+            return
+        if not proxy._c.deactivable:
+            return
+        self._ensure_enough_room()
+        self._activation_queue[proxy] = 42
+
+    def _activate(self, proxy):
+        """Activate a proxy"""
+        is_activated = proxy.activated
+        use_queue = self._max_activated != np.inf
+        is_lock_activated = self._locked_activations[proxy] != 0
+        case = (is_activated, use_queue, is_lock_activated)
+
+        self._assert_states_logic(case, proxy)
+
+        if case == (False, True, False):
+            self._ensure_enough_room()
+            proxy._activate()
+            self._activation_queue[proxy] = 42
+        elif case == (False, False, False):
+            proxy._activate()
+
+    def _deactivate(self, proxy):
+        """Deactivate a proxy"""
+        is_activated = proxy.activated
+        use_queue = self._max_activated != np.inf
+        is_lock_activated = self._locked_activations[proxy] != 0
+        case = (is_activated, use_queue, is_lock_activated)
+
+        self._assert_states_logic(case, proxy)
+
+        if case == (True, True, False):
+            proxy._deactivate()
+            del self._activation_queue[proxy]
+        elif case == (True, False, False):
+            proxy._deactivate()
+
+    def _lock_activate(self, proxy):
+        """Lock this proxy in the activated state, this lock is recursive"""
+        is_activated = proxy.activated
+        use_queue = self._max_activated != np.inf
+        is_lock_activated = self._locked_activations[proxy] != 0
+        case = (is_activated, use_queue, is_lock_activated)
+
+        self._assert_states_logic(case, proxy)
+
+        if case == (True, True, True):
+            self._locked_activations[proxy] += 1
+        elif case == (True, True, False):
+            del self._activation_queue[proxy]
+            self._locked_activations[proxy] = 1
+        elif case == (True, False, True):
+            self._locked_activations[proxy] += 1
+        elif case == (True, False, False):
+            self._locked_activations[proxy] = 1
+        elif case == (False, True, False):
+            self._ensure_enough_room()
+            proxy._activate()
+            self._locked_activations[proxy] = 1
+        elif case == (False, False, False):
+            proxy._activate()
+            self._locked_activations[proxy] = 1
+
+    def _unlock_activate(self, proxy):
+        """Unlock this proxy from the activated state, this lock is recursive"""
+        is_activated = proxy.activated
+        use_queue = self._max_activated != np.inf
+        is_lock_activated = self._locked_activations[proxy] != 0
+        case = (is_activated, use_queue, is_lock_activated)
+
+        self._assert_states_logic(case, proxy)
+
+        if case == (True, True, True):
+            self._locked_activations[proxy] -= 1
+            if self._locked_activations[proxy] == 0:
+                self._activation_queue[proxy] = 42
+        elif case == (True, True, False):
+            assert False, 'unlocking but not locked'
+        elif case == (True, False, True):
+            self._locked_activations[proxy] -= 1
+        elif case == (True, False, False):
+            assert False, 'unlocking but not locked'
+        elif case == (False, True, False):
+            assert False, 'unlocking but not locked'
+        elif case == (False, False, False):
+            assert False, 'unlocking but not locked'

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -112,22 +112,28 @@ class Proxy(object):
         ------------
         - If the source is not deactivable: fails silently
         - If the source is already deactivated: fails silently
+        - If some cases a source can't be deactivated, like during a `Vector.iter_data` fails
+          silently
         """
         if not self.deactivable:
             return
         self._ds._deactivate(self)
 
     def _activate(self):
+        """The actual implentation of the activation process"""
         raise NotImplementedError('Should be implemented by deactivable subclasses') # pragma: no cover
 
     def _deactivate(self):
+        """The actual implentation of the deactivation process"""
         raise NotImplementedError('Should be implemented by deactivable subclasses') # pragma: no cover
 
     def _lock_activate(self):
+        """Once locked a source cannot be deactivated"""
         assert self.deactivable
         self._ds._lock_activate(self)
 
     def _unlock_activate(self):
+        """Once unlocked a source may be deactivated again"""
         assert self.deactivable
         self._ds._unlock_activate(self)
 

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -19,11 +19,6 @@ class Proxy(object):
            - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
            - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
              `Proxy._Constants.wkt_origin`
-        - Since some proxies cannot be deactivated (i.e. MEM, MEMORY drivers and Recipe), the
-          `deactivable` property may be implemented to prevent those proxies to interfere with
-          activation lru mechanisms.
-        - Since some proxies cannot be pickled (i.e. MEM, MEMORY), the `picklable` property may be
-          implemented to prevent all pickling attempts.
         - The `_Constants` class is contant '^_^
 
         """
@@ -33,14 +28,6 @@ class Proxy(object):
             assert not kwargs, 'kwargs should be empty at this points of code: {}'.format(
                 list(kwargs.keys())
             )
-
-        @property
-        def deactivable(self):
-            return True
-
-        @property
-        def picklable(self):
-            return True
 
     def __init__(self, ds, consts, rect):
         wkt_origin = consts.wkt
@@ -82,6 +69,23 @@ class Proxy(object):
 
     # Activation mechanisms ********************************************************************* **
     @property
+    def deactivable(self):
+        """
+        - Since some proxies cannot be deactivated (i.e. MEM, MEMORY drivers and Recipe), the
+          `deactivable` property may be implemented to prevent those proxies to interfere with
+          activation lru mechanisms.
+        """
+        return True
+
+    @property
+    def picklable(self):
+        """
+        - Since some proxies cannot be pickled (i.e. MEM, MEMORY), the `picklable` property may be
+          implemented to prevent all pickling attempts.
+        """
+        return True
+
+    @property
     def activated(self):
         """
 
@@ -102,7 +106,7 @@ class Proxy(object):
           function may fail if the DataSource's activation queue is full
           (see DataSource.__init__@max_activated)
         """
-        if not self._c.deactivable:
+        if not self.deactivable:
             return
         self._ds._activate(self)
 
@@ -113,7 +117,7 @@ class Proxy(object):
         - If the source is not deactivable: fails silently
         - If the source is already deactivated: fails silently
         """
-        if not self._c.deactivable:
+        if not self.deactivable:
             return
         self._ds._deactivate(self)
 
@@ -124,11 +128,11 @@ class Proxy(object):
         raise NotImplementedError('Should be implemented by deactivable subclasses') # pragma: no cover
 
     def _lock_activate(self):
-        assert self._c.deactivable
+        assert self.deactivable
         self._ds._lock_activate(self)
 
     def _unlock_activate(self):
-        assert self._c.deactivable
+        assert self.deactivable
         self._ds._unlock_activate(self)
 
     # The end *********************************************************************************** **

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -8,7 +8,7 @@ class Proxy(object):
     class _Constants(object):
         """Bundles all constant information about a instance of the above class. It allows the above
         class to:
-        - function when its gdal backend object is not available (The above class is then said to be suspended)
+        - function when its gdal backend object is not available (The above class is then said to be deactivated)
         - fully recreate its gdal backend object
         - be easilly pickled/unpickled
 
@@ -19,9 +19,9 @@ class Proxy(object):
            - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
            - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
              `Proxy._Constants.wkt_origin`
-        - Since some proxies cannot be suspended (i.e. MEM, MEMORY drivers and Recipe), the
-          `suspendable` property may be implemented to prevent those proxies to interfere with lru
-          mechanisms.
+        - Since some proxies cannot be deactivated (i.e. MEM, MEMORY drivers and Recipe), the
+          `deactivable` property may be implemented to prevent those proxies to interfere with
+          activation lru mechanisms.
         - Since some proxies cannot be pickled (i.e. MEM, MEMORY), the `picklable` property may be
           implemented to prevent all pickling attempts.
         - The `_Constants` class is contant '^_^
@@ -37,7 +37,7 @@ class Proxy(object):
             )
 
         @property
-        def suspendable(self):
+        def deactivable(self):
             return True
 
         @property
@@ -81,3 +81,40 @@ class Proxy(object):
         if not self._sr_origin:
             return None # pragma: no cover
         return self._sr_origin.ExportToProj4()
+
+    # Activation mechanisms ********************************************************************* **
+    @property
+    def activated(self):
+        """
+
+        Returns
+        -------
+        bool
+        If the source is not deactivable, returns `True`
+        """
+        raise NotImplementedError('Should be implemented by subclass')
+
+    def activate(self):
+        """
+        Corner cases
+        ------------
+        - If the source is not deactivable: fails silently
+        - If the source is already activated: fails silently
+        - Since some operations requires a proxy to stay activated (like Vector.iter_data), this
+          function may fail if the DataSource's activation queue is full
+          (see DataSource.__init__@max_activated)
+
+        """
+        raise NotImplementedError('Should be implemented by subclass')
+
+    def deactivate(self):
+        """
+        Corner cases
+        ------------
+        - If the source is not deactivable: fails silently
+        - If the source is already deactivated: fails silently
+        """
+        raise NotImplementedError('Should be implemented by subclass')
+
+    # The end *********************************************************************************** **
+    # ******************************************************************************************* **

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -29,9 +29,7 @@ class Proxy(object):
         """
 
         def __init__(self, ds, **kwargs):
-            print('Proxy._Constants __init__', kwargs)
             self.wkt = kwargs.pop('wkt')
-
             assert not kwargs, 'kwargs should be empty at this points of code: {}'.format(
                 list(kwargs.keys())
             )

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -19,8 +19,11 @@ class Proxy(object):
            - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
            - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
              `Proxy._Constants.wkt_origin`
-        - Since some proxies cannot be suspended (i.e. MEM and MEMORY drivers), the `suspendable`
-          property may be implemented to prevent all `suspend` and `pickle` operations.
+        - Since some proxies cannot be suspended (i.e. MEM, MEMORY drivers and Recipe), the
+          `suspendable` property may be implemented to prevent those proxies to interfere with lru
+          mechanisms.
+        - Since some proxies cannot be pickled (i.e. MEM, MEMORY), the `picklable` property may be
+          implemented to prevent all pickling attempts.
         - The `_Constants` class is contant '^_^
 
         """
@@ -35,6 +38,10 @@ class Proxy(object):
 
         @property
         def suspendable(self):
+            return True
+
+        @property
+        def picklable(self):
             return True
 
     def __init__(self, ds, consts, rect):

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -120,10 +120,10 @@ class Proxy(object):
         self._ds._deactivate(self)
 
     def _activate(self):
-        raise NotImplementedError('Should be implemented by deactivable subclasses')
+        raise NotImplementedError('Should be implemented by deactivable subclasses') # pragma: no cover
 
     def _deactivate(self):
-        raise NotImplementedError('Should be implemented by deactivable subclasses')
+        raise NotImplementedError('Should be implemented by deactivable subclasses') # pragma: no cover
 
     def _lock_activate(self):
         assert self._c.deactivable

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -19,7 +19,7 @@ class Proxy(object):
            - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
            - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
              `Proxy._Constants.wkt_origin`
-        - The `_Constants` class is contant '^_^
+        - The `_Constants` class is contant and does not make side effects
 
         """
 

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -92,7 +92,7 @@ class Proxy(object):
         bool
         If the source is not deactivable, returns `True`
         """
-        raise NotImplementedError('Should be implemented by subclass')
+        raise NotImplementedError('Should be implemented by all subclasses')
 
     def activate(self):
         """
@@ -103,9 +103,10 @@ class Proxy(object):
         - Since some operations requires a proxy to stay activated (like Vector.iter_data), this
           function may fail if the DataSource's activation queue is full
           (see DataSource.__init__@max_activated)
-
         """
-        raise NotImplementedError('Should be implemented by subclass')
+        if not self._c.deactivable:
+            return
+        self._ds._activate(self)
 
     def deactivate(self):
         """
@@ -114,7 +115,23 @@ class Proxy(object):
         - If the source is not deactivable: fails silently
         - If the source is already deactivated: fails silently
         """
-        raise NotImplementedError('Should be implemented by subclass')
+        if not self._c.deactivable:
+            return
+        self._ds._deactivate(self)
+
+    def _activate(self):
+        raise NotImplementedError('Should be implemented by deactivable subclasses')
+
+    def _deactivate(self):
+        raise NotImplementedError('Should be implemented by deactivable subclasses')
+
+    def _lock_activate(self):
+        assert self._c.deactivable
+        self._ds._lock_activate(self)
+
+    def _unlock_activate(self):
+        assert self._c.deactivable
+        self._ds._unlock_activate(self)
 
     # The end *********************************************************************************** **
     # ******************************************************************************************* **

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -5,15 +5,41 @@ from osgeo import osr
 class Proxy(object):
     """Base class to all sources"""
 
+    class _Constants(object):
+
+        def __init__(self, ds, **kwargs):
+            print('Proxy._Constants __init__', kwargs)
+            # Opening informations
+            # None
+
+            # GDAL informations
+            if 'gdal_ds' in kwargs:
+                gdal_ds = kwargs.pop('gdal_ds')
+                kwargs['wkt_origin'] = gdal_ds.GetProjection()
+            self.wkt_origin = kwargs.pop('wkt_origin')
+
+            if kwargs:
+                raise RuntimeError('kwargs should be empty at this points of code: {}'.format(
+                    list(kwargs.keys())
+                ))
+
+        @property
+        def suspendable(self):
+            return True
+
     def __init__(self, ds, wkt, rect):
         wkt_origin = wkt
         del wkt
 
+        # If `ds` mode overrides file's origin
         if ds._wkt_origin:
             wkt_origin = ds._wkt_origin
+
+        # If origin missing and `ds` provides a fallback origin
         if not wkt_origin and ds._wkt_implicit:
             wkt_origin = ds._wkt_implicit
 
+        # Whether or not `ds` enforces a work projection
         if wkt_origin:
             sr_origin = osr.SpatialReference(wkt_origin)
         else:

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -38,7 +38,6 @@ class Proxy(object):
             return True
 
     def __init__(self, ds, consts, rect):
-
         wkt_origin = consts.wkt
 
         # If `ds` mode overrides file's origin

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -9,27 +9,19 @@ class Proxy(object):
 
         def __init__(self, ds, **kwargs):
             print('Proxy._Constants __init__', kwargs)
-            # Opening informations
-            # None
+            self.wkt = kwargs.pop('wkt')
 
-            # GDAL informations
-            if 'gdal_ds' in kwargs:
-                gdal_ds = kwargs.pop('gdal_ds')
-                kwargs['wkt_origin'] = gdal_ds.GetProjection()
-            self.wkt_origin = kwargs.pop('wkt_origin')
-
-            if kwargs:
-                raise RuntimeError('kwargs should be empty at this points of code: {}'.format(
-                    list(kwargs.keys())
-                ))
+            assert not kwargs, 'kwargs should be empty at this points of code: {}'.format(
+                list(kwargs.keys())
+            )
 
         @property
         def suspendable(self):
             return True
 
-    def __init__(self, ds, wkt, rect):
-        wkt_origin = wkt
-        del wkt
+    def __init__(self, ds, consts, rect):
+
+        wkt_origin = consts.wkt
 
         # If `ds` mode overrides file's origin
         if ds._wkt_origin:
@@ -47,6 +39,7 @@ class Proxy(object):
 
         to_work, to_file = ds._get_transforms(sr_origin, rect)
 
+        self._c = consts
         self._ds = ds
         self._wkt_origin = wkt_origin
         self._sr_origin = sr_origin

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -6,8 +6,7 @@ class Proxy(object):
     """Base class to all sources"""
 
     class _Constants(object):
-        """Bundles all constant information about a instance of the above class. It allows the above
-        class to:
+        """Bundles all constant information about a proxy object. It allows a proxy class to:
         - function when its gdal backend object is not available (The above class is then said to be deactivated)
         - fully recreate its gdal backend object
         - be easilly pickled/unpickled
@@ -19,7 +18,7 @@ class Proxy(object):
            - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
            - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
              `Proxy._Constants.wkt_origin`
-        - The `_Constants` class is contant and does not make side effects
+        - The `_Constants` class is contant and does not make any side effect
 
         """
 
@@ -70,48 +69,45 @@ class Proxy(object):
     # Activation mechanisms ********************************************************************* **
     @property
     def deactivable(self):
-        """
-        - Since some proxies cannot be deactivated (i.e. MEM, MEMORY drivers and Recipe), the
-          `deactivable` property may be implemented to prevent those proxies to interfere with
-          activation lru mechanisms.
+        """Whether or not the source is deactivable.
+        Those sources can't be deactivated:
+        - Raster with the 'MEM' driver
+        - Vector with the `Memory` driver
+        - Raster recipe
         """
         return True
 
     @property
     def picklable(self):
-        """
-        - Since some proxies cannot be pickled (i.e. MEM, MEMORY), the `picklable` property may be
-          implemented to prevent all pickling attempts.
+        """Whether or not the source can be pickled
+        Those sources can't be pickled:
+        - Raster with the 'MEM' driver
+        - Vector with the `Memory` driver
         """
         return True
 
     @property
     def activated(self):
-        """
-
-        Returns
-        -------
-        bool
-        If the source is not deactivable, returns `True`
-        """
+        """Whether or not the source is currently activated"""
         raise NotImplementedError('Should be implemented by all subclasses')
 
     def activate(self):
-        """
+        """Activate a source
+
         Corner cases
         ------------
         - If the source is not deactivable: fails silently
         - If the source is already activated: fails silently
         - Since some operations requires a proxy to stay activated (like Vector.iter_data), this
           function may fail if the DataSource's activation queue is full
-          (see DataSource.__init__@max_activated)
         """
         if not self.deactivable:
             return
         self._ds._activate(self)
 
     def deactivate(self):
-        """
+        """Deactivate a source
+
         Corner cases
         ------------
         - If the source is not deactivable: fails silently

--- a/buzzard/_proxy.py
+++ b/buzzard/_proxy.py
@@ -6,6 +6,24 @@ class Proxy(object):
     """Base class to all sources"""
 
     class _Constants(object):
+        """Bundles all constant information about a instance of the above class. It allows the above
+        class to:
+        - function when its gdal backend object is not available (The above class is then said to be suspended)
+        - fully recreate its gdal backend object
+        - be easilly pickled/unpickled
+
+        Guidelines
+        ----------
+        - The constructor must be usable for constructions both from gdal pointers and unpickling
+        - An information should not be duplicated inside a `_Constants` object
+           - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
+           - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
+             `Proxy._Constants.wkt_origin`
+        - Since some proxies cannot be suspended (i.e. MEM and MEMORY drivers), the `suspendable`
+          property may be implemented to prevent all `suspend` and `pickle` operations.
+        - The `_Constants` class is contant '^_^
+
+        """
 
         def __init__(self, ds, **kwargs):
             print('Proxy._Constants __init__', kwargs)

--- a/buzzard/_raster.py
+++ b/buzzard/_raster.py
@@ -110,7 +110,10 @@ class Raster(Proxy, RasterGetSetMixin, RasterUtilsMixin, RemapMixin):
                 # code...
         """
         def _close():
+            if self._ds._is_locked_activate(self):
+                raise RuntimeError('Attempting to close a `buzz.Raster` before `TBD`')
             self._ds._unregister(self)
+            self.deactivate()
             del self._gdal_ds
             del self._ds
 

--- a/buzzard/_raster.py
+++ b/buzzard/_raster.py
@@ -17,6 +17,7 @@ class Raster(Proxy, RasterGetSetMixin, RasterUtilsMixin, RemapMixin):
     """Abstract class to all raster sources"""
 
     class _Constants(Proxy._Constants):
+        """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
             print('Raster._Constants __init__', kwargs)

--- a/buzzard/_raster.py
+++ b/buzzard/_raster.py
@@ -16,6 +16,28 @@ from buzzard import _tools
 class Raster(Proxy, RasterGetSetMixin, RasterUtilsMixin, RemapMixin):
     """Abstract class to all raster sources"""
 
+    class _Constants(Proxy._Constants):
+
+        def __init__(self, ds, **kwargs):
+            print('Raster._Constants __init__', kwargs)
+            # Opening informations
+            # None
+
+            # GDAL informations
+            if 'gdal_ds' in kwargs:
+                gdal_ds = kwargs['gdal_ds']
+                kwargs['fp_origin'] = Footprint(
+                    gt=gdal_ds.GetGeoTransform(),
+                    rsize=(gdal_ds.RasterXSize, gdal_ds.RasterYSize),
+                )
+                kwargs['band_schema'] = Raster._band_schema_of_gdal_ds(gdal_ds)
+                kwargs['dtype'] = conv.dtype_of_gdt_downcast(gdal_ds.GetRasterBand(1).DataType)
+            self.fp_origin = kwargs.pop('fp_origin')
+            self.band_schema = kwargs.pop('band_schema')
+            self.dtype = kwargs.pop('dtype')
+
+            super(Raster._Constants, self).__init__(ds, **kwargs)
+
     def __init__(self, ds, gdal_ds):
         """Instanciated by DataSource class, instanciation by user is undefined"""
         fp_origin = Footprint(

--- a/buzzard/_raster.py
+++ b/buzzard/_raster.py
@@ -20,7 +20,6 @@ class Raster(Proxy, RasterGetSetMixin, RasterUtilsMixin, RemapMixin):
         """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
-            print('Raster._Constants __init__', kwargs)
             # GDAL informations
             if 'gdal_ds' in kwargs:
                 gdal_ds = kwargs.pop('gdal_ds')

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -151,7 +151,22 @@ class RasterPhysical(Raster):
     def _activate(self):
         assert self.deactivable
         assert self._gdal_ds is None
-        self._gdal_ds = self._open_file(self.path, self.driver, self.open_options, self.mode)
+        gdal_ds = self._open_file(self.path, self.driver, self.open_options, self.mode)
+
+        # Check that self._c hasn't changed
+        consts_check = RasterPhysical._Constants(
+            self._ds, gdal_ds=gdal_ds, open_options=self.open_options, mode=self.mode
+        )
+        new = consts_check.__dict__
+        old = self._c.__dict__
+        for k in new.keys():
+            oldv = old[k]
+            newv = new[k]
+            if oldv != newv:
+                raise RuntimeError("Raster's `{}` changed between deactivation and activation!\nold: `{}`\nnew: `{}` ".format(
+                    k, oldv, newv
+                ))
+        self._gdal_ds = gdal_ds
 
     def _deactivate(self):
         assert self.deactivable

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -15,6 +15,48 @@ from buzzard._raster import Raster
 class RasterPhysical(Raster):
     """Concrete class of raster sources containing physical data"""
 
+    class _Constants(Raster._Constants):
+        """Bundles all constant information about a instance of the above class. It allows the above
+        class to:
+        - function when its gdal backend object is not available (The above class is then said to be suspended)
+        - fully recreate its gdal backend object
+        - be easilly pickled/unpickled
+
+        Guidelines
+        ----------
+        - The constructor must be usable for constructions both from gdal pointers and unpickling
+        - An information should not be duplicated inside a `_Constants` object
+           - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
+           - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
+             `Proxy._Constants.wkt_origin`
+        - Since some proxies cannot be suspended (i.e. MEM and MEMORY drivers), the `suspendable`
+          property may be implemented to prevent all `suspend` and `pickle` operations.
+        - The `_Constants` class is contant '^_^
+
+        """
+
+        def __init__(self, ds, **kwargs):
+            print('RasterPhysical._Constants __init__', kwargs)
+            # Opening informations
+            self.mode = kwargs.pop('mode')
+            self.open_options = kwargs.pop('open_options')
+
+            # GDAL informations
+            if 'gdal_ds' in kwargs:
+                gdal_ds = kwargs['gdal_ds']
+                kwargs['path'] = gdal_ds.GetDescription()
+                kwargs['driver'] = gdal_ds.GetDriver().ShortName
+            self.driver = kwargs.pop('driver')
+            self.path = kwargs.pop('path')
+
+            super(RasterPhysical._Constants, self).__init__(ds, **kwargs)
+
+        @property
+        def suspendable(self):
+            v = 'MEM' not in self.driver
+            v &= super(RasterPhysical._Constants, self).suspendable
+            return v
+
     @classmethod
     def _create_file(cls, path, fp, dtype, band_count, band_schema, driver, options, sr):
         """Create a raster datasource"""

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -140,22 +140,14 @@ class RasterPhysical(Raster):
         """See buzz.Proxy.activated"""
         return self._gdal_ds is not None
 
-    @functools.wraps(Proxy.activate)
-    def activate(self):
-        """See buzz.Proxy.activate"""
-        # assert False, 'TODO'
-
-    @functools.wraps(Proxy.deactivate)
-    def deactivate(self):
-        """See buzz.Proxy.deactivate"""
-        # assert False, 'TODO'
-
     def _activate(self):
-        assert not self._activated
+        assert self._c.deactivable
+        assert self._gdal_ds is None
         self._gdal_ds = self._open_file(self.path, self.driver, self.open_options, self.mode)
 
     def _deactivate(self):
-        assert self._activated
+        assert self._c.deactivable
+        assert self._gdal_ds is not None
         self._gdal_ds = None
 
     # Raster write operations ******************************************************************* **

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -21,7 +21,6 @@ class RasterPhysical(Raster):
         """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
-            print('RasterPhysical._Constants __init__', kwargs)
             # Opening informations
             self.mode = kwargs.pop('mode')
             self.open_options = kwargs.pop('open_options')

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -140,7 +140,7 @@ class RasterPhysical(Raster):
 
     # Activation mechanisms ********************************************************************* **
     @property
-    @functools.wraps(Proxy.activated)
+    @functools.wraps(Proxy.activated.fget)
     def activated(self):
         """See buzz.Proxy.activated"""
         return self._gdal_ds is not None

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -66,7 +66,7 @@ class RasterPhysical(Raster):
             if err:
                 raise Exception('Could not delete %s' % path)
 
-        options = [str(arg) for arg in options] if len(options) else []
+        options = [str(arg) for arg in options]
         gdal_ds = dr.Create(
             path, fp.rsizex, fp.rsizey, band_count, conv.gdt_of_any_equiv(dtype), options
         )
@@ -85,7 +85,7 @@ class RasterPhysical(Raster):
     @classmethod
     def _open_file(cls, path, driver, options, mode):
         """Open a raster datasource"""
-        options = [str(arg) for arg in options] if len(options) else []
+        options = [str(arg) for arg in options]
         gdal_ds = gdal.OpenEx(
             path,
             conv.of_of_mode(mode) | conv.of_of_str('raster'),
@@ -98,10 +98,10 @@ class RasterPhysical(Raster):
             ))
         return gdal_ds
 
-    def __init__(self, ds, gdal_ds, mode):
-        """Instanciated by DataSource class, instanciation by user is undefined"""
-        Raster.__init__(self, ds, gdal_ds)
-        self._mode = mode
+    # def __init__(self, ds, gdal_ds, mode):
+    #     """Instanciated by DataSource class, instanciation by user is undefined"""
+    #     Raster.__init__(self, ds, gdal_ds)
+    #     self._mode = mode
 
     @property
     def delete(self):
@@ -115,7 +115,7 @@ class RasterPhysical(Raster):
         >>> with ds.create_araster('/tmp/tmp.tif', fp, float, 1).delete as tmp:
                 # code...
         """
-        if self._mode != 'w':
+        if self._c.mode != 'w':
             raise RuntimeError('Cannot remove a read-only file')
 
         def _delete():
@@ -135,12 +135,12 @@ class RasterPhysical(Raster):
     @property
     def mode(self):
         """Get raster open mode"""
-        return str(self._mode)
+        return self._c.mode
 
     @property
     def path(self):
         """Get raster file path"""
-        return self._gdal_ds.GetDescription()
+        return self._c.path
 
     def set_data(self, array, fp=None, band=1, interpolation='cv_area', mask=None, op=np.rint):
         """Set `data` located at `fp` in raster file. An optional `mask` may be provided.
@@ -181,7 +181,7 @@ class RasterPhysical(Raster):
 
         """
 
-        if self._mode != 'w':
+        if self._c.mode != 'w':
             raise RuntimeError('Cannot write a read-only file')
 
         # Normalize fp parameter
@@ -252,7 +252,7 @@ class RasterPhysical(Raster):
         | complex    | 1j, 2j, 3j, ... | Mask of band `i` |
 
         """
-        if self._mode != 'w':
+        if self._c.mode != 'w':
             raise RuntimeError('Cannot write a read-only file')
 
         bands, _ = _tools.normalize_band_parameter(band, len(self), self._shared_band_index)

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -16,24 +16,7 @@ class RasterPhysical(Raster):
     """Concrete class of raster sources containing physical data"""
 
     class _Constants(Raster._Constants):
-        """Bundles all constant information about a instance of the above class. It allows the above
-        class to:
-        - function when its gdal backend object is not available (The above class is then said to be suspended)
-        - fully recreate its gdal backend object
-        - be easilly pickled/unpickled
-
-        Guidelines
-        ----------
-        - The constructor must be usable for constructions both from gdal pointers and unpickling
-        - An information should not be duplicated inside a `_Constants` object
-           - i.e. Raster.nodata can be derived from Raster._Constants.band_schema
-           - i.e. Raster.fp can be derived from `ds`, `Raster._Constants.fp_origin` and
-             `Proxy._Constants.wkt_origin`
-        - Since some proxies cannot be suspended (i.e. MEM and MEMORY drivers), the `suspendable`
-          property may be implemented to prevent all `suspend` and `pickle` operations.
-        - The `_Constants` class is contant '^_^
-
-        """
+        """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
             print('RasterPhysical._Constants __init__', kwargs)
@@ -46,8 +29,8 @@ class RasterPhysical(Raster):
                 gdal_ds = kwargs['gdal_ds']
                 kwargs['path'] = gdal_ds.GetDescription()
                 kwargs['driver'] = gdal_ds.GetDriver().ShortName
-            self.driver = kwargs.pop('driver')
             self.path = kwargs.pop('path')
+            self.driver = kwargs.pop('driver')
 
             super(RasterPhysical._Constants, self).__init__(ds, **kwargs)
 
@@ -180,7 +163,6 @@ class RasterPhysical(Raster):
         | complex    | 1j, 2j, 3j, ... | Mask of band `i` |
 
         """
-
         if self._c.mode != 'w':
             raise RuntimeError('Cannot write a read-only file')
 

--- a/buzzard/_raster_physical.py
+++ b/buzzard/_raster_physical.py
@@ -149,6 +149,7 @@ class RasterPhysical(Raster):
         return self._gdal_ds is not None
 
     def _activate(self):
+        """See buzz.Proxy._activate"""
         assert self.deactivable
         assert self._gdal_ds is None
         gdal_ds = self._open_file(self.path, self.driver, self.open_options, self.mode)
@@ -169,6 +170,7 @@ class RasterPhysical(Raster):
         self._gdal_ds = gdal_ds
 
     def _deactivate(self):
+        """See buzz.Proxy._deactivate"""
         assert self.deactivable
         assert self._gdal_ds is not None
         self._gdal_ds = None

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -23,7 +23,6 @@ class RasterRecipe(Raster):
         """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
-            print('RasterRecipe._Constants __init__', kwargs)
             self.fn_list = kwargs.pop('fn_list')
             super(RasterRecipe._Constants, self).__init__(ds, **kwargs)
 

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -101,7 +101,7 @@ class RasterRecipe(Raster):
             }
             meta.update({k: v[i - 1] for (k, v) in band_schema.items()})
             top.append(cls._create_vrt_band_xml(i, uuidstr, dtype, **meta))
-        return xml.tostring(top, 'unicode')
+        return xml.tostring(top, 'us-ascii')
 
     @staticmethod
     def _create_vrt_band_xml(i, uuidstr, dtype, nodata, interpretation, offset, scale, mask):
@@ -147,7 +147,7 @@ class RasterRecipe(Raster):
 
     # Activation mechanisms ********************************************************************* **
     @property
-    @functools.wraps(Proxy.activated)
+    @functools.wraps(Proxy.activated.fget)
     def activated(self):
         """See buzz.Proxy.activated"""
         return True

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as xml
 import uuid
 import logging
 import functools
+import weakref
 
 from osgeo import gdal
 
@@ -26,7 +27,7 @@ class RasterRecipe(Raster):
             self.fn_list = kwargs.pop('fn_list')
             super(RasterRecipe._Constants, self).__init__(ds, **kwargs)
 
-    _callback_registry = {}
+    _callback_registry = weakref.WeakValueDictionary()
 
     @classmethod
     def _create_vrt(cls, fp, dtype, band_count, band_schema, sr):

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -26,6 +26,10 @@ class RasterRecipe(Raster):
             self.fn_list = kwargs.pop('fn_list')
             super(RasterRecipe._Constants, self).__init__(ds, **kwargs)
 
+        @property
+        def suspendable(self):
+            return False
+
     _callback_registry = {}
 
     @classmethod

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -153,16 +153,6 @@ class RasterRecipe(Raster):
         """See buzz.Proxy.activated"""
         return True
 
-    @functools.wraps(Proxy.activate)
-    def activate(self):
-        """See buzz.Proxy.activate"""
-        pass
-
-    @functools.wraps(Proxy.deactivate)
-    def deactivate(self):
-        """See buzz.Proxy.deactivate"""
-        pass
-
     # The end *********************************************************************************** **
     # ******************************************************************************************* **
 

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -26,10 +26,6 @@ class RasterRecipe(Raster):
             self.fn_list = kwargs.pop('fn_list')
             super(RasterRecipe._Constants, self).__init__(ds, **kwargs)
 
-        @property
-        def deactivable(self):
-            return False
-
     _callback_registry = {}
 
     @classmethod
@@ -146,6 +142,12 @@ class RasterRecipe(Raster):
         return band
 
     # Activation mechanisms ********************************************************************* **
+    @property
+    @functools.wraps(Proxy.deactivable.fget)
+    def deactivable(self):
+        """See buzz.Proxy.deactivable"""
+        return False
+
     @property
     @functools.wraps(Proxy.activated.fget)
     def activated(self):

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -12,6 +12,7 @@ from buzzard._footprint import Footprint
 from buzzard._tools import conv
 from buzzard._raster import Raster
 from buzzard._env import Env
+from buzzard._proxy import Proxy
 
 LOGGER = logging.getLogger('buzzard')
 
@@ -27,7 +28,7 @@ class RasterRecipe(Raster):
             super(RasterRecipe._Constants, self).__init__(ds, **kwargs)
 
         @property
-        def suspendable(self):
+        def deactivable(self):
             return False
 
     _callback_registry = {}
@@ -66,6 +67,7 @@ class RasterRecipe(Raster):
         with Env(_gdal_trust_buzzard=True):
             return Raster.get_data(self, *args, **kwargs)
 
+    # XML creation ****************************************************************************** **
     @classmethod
     def _create_vrt_xml_str(cls, fp, dtype, band_count, band_schema, sr):
         uuidstr = str(uuid.uuid4())
@@ -143,6 +145,26 @@ class RasterRecipe(Raster):
             elt.text = str(mask)
             band.append(elt)
         return band
+
+    # Activation mechanisms ********************************************************************* **
+    @property
+    @functools.wraps(Proxy.activated)
+    def activated(self):
+        """See buzz.Proxy.activated"""
+        return True
+
+    @functools.wraps(Proxy.activate)
+    def activate(self):
+        """See buzz.Proxy.activate"""
+        pass
+
+    @functools.wraps(Proxy.deactivate)
+    def deactivate(self):
+        """See buzz.Proxy.deactivate"""
+        pass
+
+    # The end *********************************************************************************** **
+    # ******************************************************************************************* **
 
 # pylint: disable=too-many-arguments, unused-argument
 def _pixel_function_entry_point(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize,

--- a/buzzard/_raster_recipe.py
+++ b/buzzard/_raster_recipe.py
@@ -48,7 +48,7 @@ class RasterRecipe(Raster):
             gdal_ds = self._create_vrt(
                 consts.fp_origin,
                 consts.dtype,
-                len(consts.band_schema.nodata),
+                len(consts.band_schema['nodata']),
                 consts.band_schema,
                 consts.wkt,
             )

--- a/buzzard/_tools/__init__.py
+++ b/buzzard/_tools/__init__.py
@@ -5,3 +5,4 @@ Collection of private tools
 from .parameters import *
 from .context_management import *
 from .rect import *
+from .proxy_activation import *

--- a/buzzard/_tools/proxy_activation.py
+++ b/buzzard/_tools/proxy_activation.py
@@ -15,11 +15,15 @@ def ensure_activated_iteration(f):
     """
     @functools.wraps(f)
     def g(that, *args, **kwargs):
-        that._lock_activate()
+        if that._c.deactivable:
+            that._lock_activate()
         try:
             it = f(that, *args, **kwargs)
             for v in it:
                 yield v
         finally:
-            that._unlock_activate()
+            if not hasattr(that, '_ds'):
+                assert False, "It shouldn't be allowed to close a proxy before this block!!"
+            if that._c.deactivable:
+                that._unlock_activate()
     return g

--- a/buzzard/_tools/proxy_activation.py
+++ b/buzzard/_tools/proxy_activation.py
@@ -1,4 +1,3 @@
-
 import functools
 
 def ensure_activated(f):
@@ -16,11 +15,11 @@ def ensure_activated_iteration(f):
     """
     @functools.wraps(f)
     def g(that, *args, **kwargs):
-        that.activate()
+        that._lock_activate()
         try:
             it = f(that, *args, **kwargs)
             for v in it:
                 yield v
         finally:
-            that.deactivate()
+            that._unlock_activate()
     return g

--- a/buzzard/_tools/proxy_activation.py
+++ b/buzzard/_tools/proxy_activation.py
@@ -1,0 +1,26 @@
+
+import functools
+
+def ensure_activated(f):
+    """Activate a proxy before method call"""
+    @functools.wraps(f)
+    def g(that, *args, **kwargs):
+        that.activate()
+        return f(that, *args, **kwargs)
+    return g
+
+def ensure_activated_iteration(f):
+    """Activate a proxy before method call and force it to stay opened until
+    - iteration is over
+    - iterator is collected by gc
+    """
+    @functools.wraps(f)
+    def g(that, *args, **kwargs):
+        that.activate()
+        try:
+            it = f(that, *args, **kwargs)
+            for v in it:
+                yield v
+        finally:
+            that.deactivate()
+    return g

--- a/buzzard/_tools/proxy_activation.py
+++ b/buzzard/_tools/proxy_activation.py
@@ -9,13 +9,13 @@ def ensure_activated(f):
     return g
 
 def ensure_activated_iteration(f):
-    """Activate a proxy before method call and force it to stay opened until
+    """Activate a proxy before generator starts and force it to stay activated until
     - iteration is over
     - iterator is collected by gc
     """
     @functools.wraps(f)
     def g(that, *args, **kwargs):
-        if that._c.deactivable:
+        if that.deactivable:
             that._lock_activate()
         try:
             it = f(that, *args, **kwargs)
@@ -24,6 +24,6 @@ def ensure_activated_iteration(f):
         finally:
             if not hasattr(that, '_ds'):
                 assert False, "It shouldn't be allowed to close a proxy before this block!!"
-            if that._c.deactivable:
+            if that.deactivable:
                 that._unlock_activate()
     return g

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -275,9 +275,26 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
     def _activate(self):
         assert self.deactivable
         assert self._gdal_ds is None
-        self._gdal_ds, self._lyr = self._open_file(
+        gdal_ds, lyr = self._open_file(
             self.path, self._c.layer, self.driver, self.open_options, self.mode
         )
+
+        # Check that self._c hasn't changed
+        consts_check = Vector._Constants(
+            self._ds, gdal_ds=gdal_ds, lyr=lyr, open_options=self.open_options, mode=self.mode, layer=self._c.layer,
+        )
+        new = consts_check.__dict__
+        old = self._c.__dict__
+        for k in new.keys():
+            oldv = old[k]
+            newv = new[k]
+            if oldv != newv:
+                raise RuntimeError("Vector's `{}` changed between deactivation and activation!\nold: `{}`\nnew: `{}` ".format(
+                    k, oldv, newv
+                ))
+        self._gdal_ds = gdal_ds
+        self._lyr = lyr
+
 
     def _deactivate(self):
         assert self.deactivable

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -250,27 +250,20 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
     @functools.wraps(Proxy.activated)
     def activated(self):
         """See buzz.Proxy.activated"""
+        assert (self._lyr is None) == (self._gdal_ds is None)
         return self._gdal_ds is not None
 
-    @functools.wraps(Proxy.activate)
-    def activate(self):
-        """See buzz.Proxy.activate"""
-        # assert False, 'TODO'
-
-    @functools.wraps(Proxy.deactivate)
-    def deactivate(self):
-        """See buzz.Proxy.deactivate"""
-        # assert False, 'TODO'
-
     def _activate(self):
-        assert not self._activated
-        self._gdal_ds = self._open_file(
+        assert self._c.deactivable
+        assert self._gdal_ds is None
+        self._gdal_ds, self._lyr = self._open_file(
             self.path, self._c.layer, self.driver, self.open_options, self.mode
         )
 
     def _deactivate(self):
-        assert self._activated
-        self._gdal_ds = None
+        assert self._c.deactivable
+        assert self._gdal_ds is not None
+        self._gdal_ds, self._lyr = None, None
 
     # Properties ******************************************************************************** **
     @property

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -56,6 +56,10 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
             v &= super(Vector._Constants, self).suspendable
             return v
 
+        @property
+        def picklable(self):
+            return self.suspendable
+
     @classmethod
     def _create_file(cls, path, geometry, fields, layer, driver, options, sr):
         """Create a vector datasource"""

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -51,16 +51,6 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
 
             super(Vector._Constants, self).__init__(ds, **kwargs)
 
-        @property
-        def deactivable(self):
-            v = self.driver != 'Memory'
-            v &= super(Vector._Constants, self).deactivable
-            return v
-
-        @property
-        def picklable(self):
-            return self.deactivable
-
     @classmethod
     def _create_file(cls, path, geometry, fields, layer, driver, options, sr):
         """Create a vector datasource"""
@@ -262,6 +252,20 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
 
     # Activation mechanisms ********************************************************************* **
     @property
+    @functools.wraps(Proxy.deactivable.fget)
+    def deactivable(self):
+        """See buzz.Proxy.deactivable"""
+        v = self.driver != 'Memory'
+        v &= super(Vector, self).deactivable
+        return v
+
+    @property
+    @functools.wraps(Proxy.picklable.fget)
+    def picklable(self):
+        """See buzz.Proxy.picklable"""
+        return self.deactivable
+
+    @property
     @functools.wraps(Proxy.activated.fget)
     def activated(self):
         """See buzz.Proxy.activated"""
@@ -269,14 +273,14 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
         return self._gdal_ds is not None
 
     def _activate(self):
-        assert self._c.deactivable
+        assert self.deactivable
         assert self._gdal_ds is None
         self._gdal_ds, self._lyr = self._open_file(
             self.path, self._c.layer, self.driver, self.open_options, self.mode
         )
 
     def _deactivate(self):
-        assert self._c.deactivable
+        assert self.deactivable
         assert self._gdal_ds is not None
         self._gdal_ds, self._lyr = None, None
 

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -27,7 +27,6 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
         """See Proxy._Constants"""
 
         def __init__(self, ds, **kwargs):
-            print('Vector._Constants __init__', kwargs)
             # Opening informations
             self.mode = kwargs.pop('mode')
             self.open_options = kwargs.pop('open_options')

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -262,7 +262,7 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
 
     # Activation mechanisms ********************************************************************* **
     @property
-    @functools.wraps(Proxy.activated)
+    @functools.wraps(Proxy.activated.fget)
     def activated(self):
         """See buzz.Proxy.activated"""
         assert (self._lyr is None) == (self._gdal_ds is None)

--- a/buzzard/_vector.py
+++ b/buzzard/_vector.py
@@ -235,6 +235,8 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
 
             self.activate()
             lyr_name = self._lyr.GetDescription()
+            # Lose the reference to the gdal layer but keep the variable `_lyr` alive until deletion
+            # below.
             self._lyr = 42
 
             err = self._gdal_ds.DeleteLayer(lyr_name)
@@ -245,6 +247,7 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
 
             self._ds._unregister(self)
             self.deactivate()
+            del self._lyr
             del self._gdal_ds
             del self._ds
 
@@ -273,6 +276,7 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
         return self._gdal_ds is not None
 
     def _activate(self):
+        """See buzz.Proxy._activate"""
         assert self.deactivable
         assert self._gdal_ds is None
         gdal_ds, lyr = self._open_file(
@@ -295,8 +299,8 @@ class Vector(Proxy, VectorUtilsMixin, VectorGetSetMixin):
         self._gdal_ds = gdal_ds
         self._lyr = lyr
 
-
     def _deactivate(self):
+        """See buzz.Proxy._deactivate"""
         assert self.deactivable
         assert self._gdal_ds is not None
         self._gdal_ds, self._lyr = None, None

--- a/buzzard/_vector_getset_data.py
+++ b/buzzard/_vector_getset_data.py
@@ -125,19 +125,19 @@ class VectorGetSetMixin(object):
             geom = conv.ogr_of_shapely(geom)
             if geom is None:
                 raise ValueError('Could not convert `{}` of type `{}` to `ogr.Geometry`'.format(
-                    geom_type, self._type
+                    geom_type, self.type
                 ))
         elif geom_type == 'coordinates':
             geom = conv.ogr_of_coordinates(geom, self.type)
             if geom is None:
                 raise ValueError('Could not convert `{}` of type `{}` to `ogr.Geometry`'.format(
-                    geom_type, self._type
+                    geom_type, self.type
                 ))
         elif geom_type == 'shapely':
             geom = conv.ogr_of_shapely(geom)
             if geom is None:
                 raise ValueError('Could not convert `{}` of type `{}` to `ogr.Geometry`'.format(
-                    geom_type, self._type
+                    geom_type, self.type
                 ))
         else:
             assert False # pragma: no cover
@@ -155,7 +155,7 @@ class VectorGetSetMixin(object):
                     raise ValueError(
                         'Invalid geometry inserted '
                         '(allow None geometry in DataSource constructor to silence)'
-                    )
+                   )
 
             if index >= 0:
                 err = ftr.SetFID(index)

--- a/buzzard/test/test_datasource_activations.py
+++ b/buzzard/test/test_datasource_activations.py
@@ -1,0 +1,341 @@
+
+
+# pylint: disable=redefined-outer-name, unused-argument
+
+from __future__ import division, print_function
+
+import numpy as np
+import pytest
+
+import buzzard as buzz
+from buzzard.test.tools import fpeq
+
+MEMV_META = dict(
+    driver='MEMORY',
+    path='',
+    geometry='point',
+    fields=[{'name': 'region', 'type': str}],
+)
+
+V_META = dict(
+    geometry='point',
+    fields=[{'name': 'region', 'type': str}],
+)
+
+def test_vector_nofifo():
+    ds = buzz.DataSource(max_activated=np.inf)
+
+    # Test with a shapefile
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.insert_data((42, 43), ['fra'])
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False)
+
+        v1.activate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Iteration until the end
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Do not start iteration
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'Generator is instanciated by has not yet started'
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Do not finish iteration
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+            break
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Start iteration before being loaded
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False)
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Test with a memory vector
+    with ds.create_avector(**MEMV_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.insert_data((42, 43), ['fra'])
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), "can't deactivated a memory dataset"
+
+        v1.activate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Iteration until the end
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'no need to lock a memory dataset'
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Close while being activated
+    with ds.create_avector('/tmp/v1.shp', **V_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Delete while being activated
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Close while being deactivated
+    with ds.create_avector('/tmp/v1.shp', **V_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        v1.deactivate()
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Delete while being deactivated
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        v1.deactivate()
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+def test_vector_fifo1_1file():
+    ds = buzz.DataSource(max_activated=1)
+
+    # Test with a shapefile
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        v1.insert_data((42, 43), ['fra'])
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False)
+
+        v1.activate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        # Iteration until the end
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        # Do not start iteration
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True), 'Generator is instanciated by has not yet started'
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        # Do not finish iteration
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+            break
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        # Start iteration before being loaded
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False)
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, False), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 1, True)
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Test with a memory vector
+    with ds.create_avector(**MEMV_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.insert_data((42, 43), ['fra'])
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        v1.deactivate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), "can't deactivated a memory dataset"
+
+        v1.activate()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+
+        # Iteration until the end
+        it = v1.iter_data()
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'Generator is instanciated by has not yet started'
+        for _ in it:
+            assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True), 'no need to lock a memory dataset'
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+        del it
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (0, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Close while being activated
+    with ds.create_avector('/tmp/v1.shp', **V_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Delete while being activated
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Close while being deactivated
+    with ds.create_avector('/tmp/v1.shp', **V_META).close as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+        v1.deactivate()
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+    # Delete while being deactivated
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+        v1.deactivate()
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+
+def test_vector_fifo1_2files():
+    ds = buzz.DataSource(max_activated=1)
+
+    # Test with a shapefile
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        with ds.create_avector('/tmp/v2.shp', **V_META).delete as v2:
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (1, 0, False, True)
+
+            v1.insert_data((42, 43), ['fra'])
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (1, 0, True, False)
+
+            v2.insert_data((44, 45), ['ger'])
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (1, 0, False, True)
+
+            assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+            assert (len(v2), v2.get_data(0, geom_type='coordinates')) == (1, ((44, 45), 'ger'))
+
+            # Attempt to iterate on both
+            it1 = v1.iter_data()
+            next(it1)
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (0, 1, True, False)
+            it2 = v2.iter_data()
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (0, 1, True, False)
+            with pytest.raises(RuntimeError, match='simultaneous'):
+                next(it2)
+            del it2, it1
+
+def test_vector_fifo2_2files():
+    ds = buzz.DataSource(max_activated=2)
+
+    # Test with a shapefile
+    assert (ds._queued_count, ds._locked_count) == (0, 0)
+    with ds.create_avector('/tmp/v1.shp', **V_META).delete as v1:
+        assert (ds._queued_count, ds._locked_count, v1.activated) == (1, 0, True)
+
+        with ds.create_avector('/tmp/v2.shp', **V_META).delete as v2:
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (2, 0, True, True)
+
+            v1.insert_data((42, 43), ['fra'])
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (2, 0, True, True)
+
+            v2.insert_data((44, 45), ['ger'])
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (2, 0, True, True)
+
+            assert (len(v1), v1.get_data(0, geom_type='coordinates')) == (1, ((42, 43), 'fra'))
+            assert (len(v2), v2.get_data(0, geom_type='coordinates')) == (1, ((44, 45), 'ger'))
+
+            # Attempt to iterate on both
+            it1 = v1.iter_data()
+            next(it1)
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (1, 1, True, True)
+            it2 = v2.iter_data()
+            next(it2)
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (0, 2, True, True)
+            del it2, it1
+            assert (ds._queued_count, ds._locked_count, v1.activated, v2.activated) == (2, 0, True, True)
+
+def test_vector_end_while_iterating():
+    ds = buzz.DataSource()
+    v1 = ds.create_avector('/tmp/v1.shp', **V_META)
+    v1.insert_data((42, 43), ['fra'])
+    it = v1.iter_data()
+    next(it)
+    with pytest.raises(RuntimeError, match='in progress'):
+        v1.close()
+    with pytest.raises(RuntimeError, match='in progress'):
+        v1.delete()
+    with pytest.raises(RuntimeError, match='in progress'):
+        v1.delete_layer()
+
+def test_raster():
+    ds = buzz.DataSource(max_activated=2)
+    fp = buzz.Footprint(
+        tl=(0, 0),
+        size=(10, 10),
+        rsize=(10, 10),
+    )
+    with ds.create_araster('/tmp/t1.shp', fp, float, 1).delete as r1:
+        assert (ds._queued_count, ds._locked_count, r1.activated) == (1, 0, True)
+
+        with ds.create_araster('/tmp/t2.shp', fp, float, 1).delete as r2:
+            assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated) == (2, 0, True, True)
+
+            with ds.create_araster('/tmp/t3.shp', fp, float, 1).delete as r3:
+                assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated, r3.activated) == (2, 0, False, True, True)
+
+                r1.fill(1)
+                assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated, r3.activated) == (2, 0, True, False, True)
+                r2.fill(2)
+                assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated, r3.activated) == (2, 0, True, True, False)
+                r3.fill(3)
+                assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated, r3.activated) == (2, 0, False, True, True)
+
+                with pytest.raises(RuntimeError, match='max_activated'):
+                    ds.activate_all()
+
+                ds.deactivate_all()
+                assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated, r3.activated) == (0, 0, False, False, False)
+
+            assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated) == (0, 0, False, False)
+            ds.activate_all()
+            assert (ds._queued_count, ds._locked_count, r1.activated, r2.activated) == (2, 0, True, True)

--- a/buzzard/test/test_datasource_create.py
+++ b/buzzard/test/test_datasource_create.py
@@ -221,7 +221,7 @@ def test_vector(path, driver, test_fields):
 def test_gc():
     ws = weakref.WeakSet()
     fp = buzz.Footprint(
-        tl=(0, 0),
+        tl=(1, 1),
         size=(10, 10),
         rsize=(10, 10),
     )

--- a/buzzard/test/test_datasource_create.py
+++ b/buzzard/test/test_datasource_create.py
@@ -7,6 +7,8 @@ import logging
 import os
 import tempfile
 import uuid
+import weakref
+import gc
 
 import numpy as np
 from osgeo import gdal
@@ -215,3 +217,32 @@ def test_vector(path, driver, test_fields):
     for input, output in zip(features, out.iter_data()):
         if test_fields:
             assert all(v1 == v2 for (v1, v2) in zip(input[1:], output[1:]))
+
+def test_gc():
+    ws = weakref.WeakSet()
+    fp = buzz.Footprint(
+        tl=(0, 0),
+        size=(10, 10),
+        rsize=(10, 10),
+    )
+    def pxfn(fp):
+        return np.ones(fp.shape)
+
+    def _test():
+        ds = buzz.DataSource()
+        prox = ds.create_araster('', fp, float, 1, driver='MEM')
+        ds.create_vector('vec', '', 'point', driver='Memory')
+        ws.add(ds)
+        ws.add(prox)
+    _test()
+    gc.collect()
+    assert len(ws) == 0
+
+    def _test():
+        ds = buzz.DataSource()
+        prox = ds.create_recipe_araster(pxfn, fp, float)
+        ws.add(ds)
+        ws.add(prox)
+    _test()
+    gc.collect()
+    assert len(ws) == 0

--- a/buzzard/test/test_rasterrecipe.py
+++ b/buzzard/test/test_rasterrecipe.py
@@ -1,4 +1,4 @@
-"""Test big files creation / write / read"""
+"""Test raster recipes"""
 
 # pylint: disable=redefined-outer-name
 

--- a/buzzard/test/test_rasterrecipe.py
+++ b/buzzard/test/test_rasterrecipe.py
@@ -1,0 +1,91 @@
+"""Test big files creation / write / read"""
+
+# pylint: disable=redefined-outer-name
+
+from __future__ import division, print_function
+
+import numpy as np
+import pytest
+
+import buzzard as buzz
+from buzzard.test import make_tile_set
+from .tools import SRS
+
+@pytest.fixture(scope='module')
+def fps():
+    """
+    See make_tile_set
+    A B C
+    D E F
+    G H I
+    """
+    return make_tile_set.make_tile_set(3, [0.1, -0.1])
+
+def test_basic(fps):
+    ds = buzz.DataSource()
+
+    ones = ds.create_araster('', fps.AI, 'float32', 1, driver='MEM')
+    ones.fill(1)
+
+    def pxfun(fp):
+        return ones.get_data(fp=fp) * 2
+
+    # araster
+    twos = ds.create_recipe_araster(pxfun, fps.AI, 'float32')
+    assert ones.fp == twos.fp
+    assert ones.dtype == twos.dtype
+    for fp in fps.values():
+        assert (twos.get_data(fp=fp) == 2).all()
+    twos.close()
+
+    # raster
+    twos = ds.create_recipe_raster('hello', pxfun, fps.AI, 'float32')
+    assert ones.fp == twos.fp
+    assert ones.dtype == twos.dtype
+    for fp in fps.values():
+        assert (twos.get_data(fp=fp) == 2).all()
+    twos.close()
+
+    ones.close()
+
+def test_reproj():
+    sr0 = SRS[0]
+    sr1 = SRS[3]
+
+    with buzz.Env(significant=8, allow_complex_footprint=1, warnings=0):
+
+        # Create `twos`, a recipe from `sr1` to `sr0`
+        # `fp` in sr0
+        # `ds.wkt` in sr0
+        # `twos.fp` in sr0
+        # `twos.fp_origin` in sr1
+        # `pxfun@fp` in sr1
+        fp = buzz.Footprint(
+            tl=(sr0['cx'], sr0['cy']),
+            size=(2, 2),
+            rsize=(20, 20),
+        )
+        ds = buzz.DataSource(sr0['wkt'])
+        def pxfun(fp):
+            assert (twos.fp_origin & fp) == fp, 'fp should be aligned and within twos.fp'
+            return ones.get_data(fp=fp) * 2
+        twos = ds.create_recipe_araster(pxfun, fp, 'float32', sr=sr1['wkt'], band_schema={'nodata': 42})
+
+        # Create `ones`, a raster from `sr1` to `sr1`
+        # `ds2.wkt` in sr1
+        # `ones.fp` in sr1
+        # `ones.fp_origin` in sr1
+        ds2 = buzz.DataSource(sr1['wkt'])
+        ones = ds2.create_araster('', twos.fp_origin, 'float32', 1, driver='MEM', sr=sr1['wkt'], band_schema={'nodata': 42})
+        ones.fill(1)
+
+        # Test that `sr1` performs reprojection of `fp` before sending it to `pxfun`
+        assert ones.fp == ones.fp_origin, 'ones has no reproj'
+        assert twos.fp_origin == ones.fp_origin
+        assert ones.dtype == twos.dtype
+        tiles = fp.tile_count(3, 3, boundary_effect='shrink').flatten().tolist() + [fp]
+        for tile in tiles:
+            assert (twos.get_data(fp=tile) == 2).all()
+
+        twos.close()
+        ones.close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest>=3.0.7
 attrdict>=2.0.0
 pytest-cov>=2.5.1
 pylint>=1.7.1
+dask>=0.16.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ attrdict>=2.0.0
 pytest-cov>=2.5.1
 pylint>=1.7.1
 dask>=0.16.0
+distributed>=1.20.2


### PR DESCRIPTION
# Goals
1. Allow an infinite number of opened files, by closing gdal pointers with a LRU policy, and reopen those when needed (on read/writes)
2. Allow the user to `deactivate` (close gdal backend) and `activate` (open gdal backend) a proxy.
3. Make DataSource pickling possible.

# Difficulties
- The process should be the same for normal construction and unpickling. (Introduction of `_Constants` classes)
- Pickling a `RasterRecipe` should work with `cloudpickle`
- A proxy should be able to refuse a deactivation (like `MEM` and `MEMORY` gdal drivers)
- Non deactivable proxies should not count in LRU policy

# New public features
### Methods
- `(Proxy|RasterPhysical|RasterRecipe|Vector).activated`
- `(Proxy|RasterPhysical|RasterRecipe|Vector).activate`
- `(Proxy|RasterPhysical|RasterRecipe|Vector).deactivate`
- `(Raster|Vector).driver`
- `(Raster|Vector).open_options`
- `DataSource.activate_all`
- `DataSource.deactivate_all`
- `DataSource.__reduce__` (pickling)

### Parameters
- `DataSource.__init__@max_activated`

# Minor changes
- Tag `RasterRecipe` as experimental in docstring
- Fix bug in `RasterRecipe` with python 2.7
- Add unit tests for `RasterRecipe`
- Fix garbage collection bug in `RasterRecipe` (and add unit test)
- README update
- Add `dask` to `requirements-dev.txt`
