### PR TITLE
0.6.1

### DIFF
--- a/buzzard/__init__.py
+++ b/buzzard/__init__.py
@@ -3,7 +3,7 @@
 buzzard should always be imported the first time from the main thread
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # Import osgeo before cv2
 import osgeo as _

--- a/buzzard/_a_source_raster.py
+++ b/buzzard/_a_source_raster.py
@@ -193,7 +193,7 @@ class ABackSourceRaster(ABackSource, ABackSourceRasterRemapMixin):
         if self.to_work is not None:
             fp = fp_stored.move(*self.to_work([
                 fp_stored.tl, fp_stored.tr, fp_stored.br
-            ]))
+            ]), round_coordinates=True)
         else:
             fp = fp_stored
 

--- a/buzzard/_dataset_back_conversions.py
+++ b/buzzard/_dataset_back_conversions.py
@@ -136,7 +136,7 @@ class BackDatasetConversionsMixin(object):
         sr = osr.SpatialReference(wkt)
         _, to_virtual = self.get_transforms(sr, fp, 'work')
         if to_virtual:
-            fp = fp.move(*to_virtual([fp.tl, fp.tr, fp.br]))
+            fp = fp.move(*to_virtual([fp.tl, fp.tr, fp.br]), round_coordinates=True)
         return fp
 
     @staticmethod

--- a/buzzard/_footprint.py
+++ b/buzzard/_footprint.py
@@ -1553,23 +1553,7 @@ class Footprint(TileMixin, IntersectionMixin):
             if isinstance(mline, shapely.geometry.LineString):
                 mline = sg.MultiLineString([mline])
 
-        # Step 8: Temporary check for badness, until further testing of this method ************* **
-        check = arr.copy()
-        check[:] = 0
-
-        for l in mline:
-            coords = np.asarray(l) - output_offset
-            coords = self.spatial_to_raster(coords)
-            x = coords[:, 0]
-            y = coords[:, 1]
-            check[y, x] = 1
-
-        # Burning size one components since they are not transformed to lines
-        for sly, slx in ndi.find_objects(ndi.label(arr)[0]):
-            if sly.stop - sly.start == 1 and slx.stop - slx.start == 1:
-                check[sly, slx] = 1
-
-        # Step 9: Return ************************************************************************ **
+        # Step 8: Return ************************************************************************ **
         if isinstance(mline, shapely.geometry.LineString):
             return [mline]
         if isinstance(mline, shapely.geometry.MultiLineString):

--- a/buzzard/_footprint.py
+++ b/buzzard/_footprint.py
@@ -470,7 +470,7 @@ class Footprint(TileMixin, IntersectionMixin, MoveMixin):
         if round_coordinates:
             if br is None: # pragma: no cover
                 raise ValueError(
-                    'Can only round input coordinates when all parameters are probided'
+                    'Can only round input coordinates when all parameters are provided'
                 )
             tl, tr, br = self._snap_target_coordinates_before_move(tl, tr, br)
 

--- a/buzzard/_footprint_move.py
+++ b/buzzard/_footprint_move.py
@@ -1,0 +1,108 @@
+""">>> help(TileMixin)"""
+
+import numpy as np
+from buzzard._env import env
+
+class MoveMixin(object):
+    """Private mixin for the Footprint class containing move subroutines"""
+
+    def _snap_target_coordinates_before_move(self, tl1, tr1, br1):
+        rw, rh = self.rsize
+
+        # Extract `source` values *********************************************** **
+        v0 = self.pxlrvec
+        w0 = self.pxtbvec
+        norm_v0, norm_w0 = self.pxsize
+        i0 = v0 / norm_v0
+        j0 = w0 / norm_w0
+
+        # Compute `transformed values` ****************************************** **
+        v1 = (tr1 - tl1) / rw
+        w1 = (br1 - tr1) / rh
+        norm_v1 = np.linalg.norm(v1)
+        norm_w1 = np.linalg.norm(w1)
+        i1 = v1 / norm_v1
+        j1 = w1 / norm_w1
+
+        # Prepare comparison function ******************************************* **
+        largest_coord = np.abs([tl1, tr1, br1]).max()
+        spatial_precision = largest_coord * 10 ** -env.significant
+        def _are_close_enough(p, q):
+            return (np.abs(p - q) < spatial_precision).all()
+
+        # Compute `transformed and snapped values` ****************************** **
+        tl2 = tl1
+
+        # Attempt rounding to preserve `angle` and `pxsize`
+        # e.g. The transformation is just a shift
+        # e.g. The transformation is a flip or a mirror
+        i2 = np.copysign(i0, i1)
+        j2 = np.copysign(j0, j1)
+        norm_v2 = norm_v0
+        norm_w2 = norm_w0
+
+        v2 = i2 * norm_v2
+        w2 = j2 * norm_w2
+        tr2 = tl2 + v2 * rw
+        br2 = tr2 + w2 * rh
+        if _are_close_enough(tr1, tr2) and _are_close_enough(br1, br2):
+            return tl2, tr2, br2
+
+        # Attempt rounding to preserve `angle` and `pxsizex / pxsizey`
+        # e.g. The transformation is a change of unit
+        i2 = np.copysign(i0, i1)
+        j2 = np.copysign(j0, j1)
+        norm_v2 = norm_v1
+        norm_w2 = norm_v1 / norm_v0 * norm_w0
+
+        v2 = i2 * norm_v2
+        w2 = j2 * norm_w2
+        tr2 = tl2 + v2 * rw
+        br2 = tr2 + w2 * rh
+        if _are_close_enough(tr1, tr2) and _are_close_enough(br1, br2):
+            return tl2, tr2, br2
+
+        # Attempt rounding to preserve `angle`
+        # e.g. The transformation is a change of unit different on each axis
+        i2 = np.copysign(i0, i1)
+        j2 = np.copysign(j0, j1)
+        norm_v2 = norm_v1
+        norm_w2 = norm_w1
+
+        v2 = i2 * norm_v2
+        w2 = j2 * norm_w2
+        tr2 = tl2 + v2 * rw
+        br2 = tr2 + w2 * rh
+        if _are_close_enough(tr1, tr2) and _are_close_enough(br1, br2):
+            return tl2, tr2, br2
+
+        # Attempt rounding to preserve `pxsize`
+        # e.g. The transformation is a rotation
+        i2 = i1
+        j2 = j1
+        norm_v2 = norm_v0
+        norm_w2 = norm_w0
+
+        v2 = i2 * norm_v2
+        w2 = j2 * norm_w2
+        tr2 = tl2 + v2 * rw
+        br2 = tr2 + w2 * rh
+        if _are_close_enough(tr1, tr2) and _are_close_enough(br1, br2):
+            return tl2, tr2, br2
+
+        # Attempt rounding to preserve `pxsizex / pxsizey`
+        # e.g. The transformation is a rotation and a change of unit
+        i2 = i1
+        j2 = j1
+        norm_v2 = norm_v1
+        norm_w2 = norm_v1 / norm_v0 * norm_w0
+
+        v2 = i2 * norm_v2
+        w2 = j2 * norm_w2
+        tr2 = tl2 + v2 * rw
+        br2 = tr2 + w2 * rh
+        if _are_close_enough(tr1, tr2) and _are_close_enough(br1, br2):
+            return tl2, tr2, br2
+
+        # Don't perform snapping
+        return tl1, tr1, br1

--- a/buzzard/_numpy_raster.py
+++ b/buzzard/_numpy_raster.py
@@ -73,11 +73,16 @@ class BackNumpyRaster(ABackStoredRaster):
                 dst_nodata,
                 self.dtype
             )
-        key = list(samplefp.slice_in(self.fp)) + [self._best_indexers_of_channel_ids(channel_ids)]
+        chans_indexer = self._best_indexers_of_channel_ids(channel_ids)
+        key = list(samplefp.slice_in(self.fp)) + [chans_indexer]
         key = tuple(key)
         array = self._arr[key]
         if self._should_tranform:
-            array = array * self.channels_schema['scale'] + self.channels_schema['offset']
+            array = (
+                array *
+                np.asarray(self.channels_schema['scale'])[chans_indexer] +
+                np.asarray(self.channels_schema['offset'])[chans_indexer]
+            )
         array = self.remap(
             samplefp,
             fp,

--- a/buzzard/srs/__init__.py
+++ b/buzzard/srs/__init__.py
@@ -19,15 +19,14 @@ def wkt_of_any(string):
         return out
     else:
         prj = None
-        with Env(_osgeo_use_exceptions=False):
-            gdal_ds = gdal.OpenEx(string, conv.of_of_str('raster'))
-            if gdal_ds is not None:
-                prj = gdal_ds.GetProjection()
-            gdal_ds = gdal.OpenEx(string, conv.of_of_str('vector'))
-            if gdal_ds is not None:
-                lyr = gdal_ds.GetLayerByIndex(0)
-                if lyr is not None:
-                    prj = lyr.GetSpatialRef()
+        gdal_ds = gdal.OpenEx(string, conv.of_of_str('raster'))
+        if gdal_ds is not None:
+            prj = gdal_ds.GetProjection()
+        gdal_ds = gdal.OpenEx(string, conv.of_of_str('vector'))
+        if gdal_ds is not None:
+            lyr = gdal_ds.GetLayerByIndex(0)
+            if lyr is not None:
+                prj = lyr.GetSpatialRef()
         if prj is not None:
             return prj.ExportToWkt()
     raise ValueError('Could not convert to wkt ({})'.format(str(gdal.GetLastErrorMsg()).strip('\n')))
@@ -41,25 +40,24 @@ def wkt_same(a, b):
     return bool(sra.IsSame(srb))
 
 def _details_of_file(path):
-    with Env(_osgeo_use_exceptions=False):
-        gdal_ds = gdal.OpenEx(path, conv.of_of_str('raster'))
-        if gdal_ds is not None:
-            aff = affine.Affine.from_gdal(*gdal_ds.GetGeoTransform())
-            w, h = gdal_ds.RasterXSize, gdal_ds.RasterYSize
-            cx, cy = aff * [w / 2, h / 2]
-            return gdal_ds.GetProjection(), (cx, cy)
-        gdal_ds = gdal.OpenEx(path, conv.of_of_str('vector'))
-        if gdal_ds is not None:
-            lyr = gdal_ds.GetLayerByIndex(0)
-            if lyr is None:
-                raise ValueError('Could not open file layer')
-            extent = lyr.GetExtent()
-            if extent is None:
-                raise ValueError('Could not compute extent')
-            minx, maxx, miny, maxy = extent
-            cx, cy = (maxx + minx) / 2, (maxy + miny) / 2
-            return lyr.GetSpatialRef().ExportToWkt(), (cx, cy)
-        raise ValueError('Could not open file')
+    gdal_ds = gdal.OpenEx(path, conv.of_of_str('raster'))
+    if gdal_ds is not None:
+        aff = affine.Affine.from_gdal(*gdal_ds.GetGeoTransform())
+        w, h = gdal_ds.RasterXSize, gdal_ds.RasterYSize
+        cx, cy = aff * [w / 2, h / 2]
+        return gdal_ds.GetProjection(), (cx, cy)
+    gdal_ds = gdal.OpenEx(path, conv.of_of_str('vector'))
+    if gdal_ds is not None:
+        lyr = gdal_ds.GetLayerByIndex(0)
+        if lyr is None:
+            raise ValueError('Could not open file layer')
+        extent = lyr.GetExtent()
+        if extent is None:
+            raise ValueError('Could not compute extent')
+        minx, maxx, miny, maxy = extent
+        cx, cy = (maxx + minx) / 2, (maxy + miny) / 2
+        return lyr.GetSpatialRef().ExportToWkt(), (cx, cy)
+    raise ValueError('Could not open file')
 
 def wkt_of_file(path, center=False, unit=None, implicit_unit='m'):
     """Retrieve projection of file as wkt.

--- a/buzzard/test/test_footprint_move.py
+++ b/buzzard/test/test_footprint_move.py
@@ -1,0 +1,103 @@
+# pylint: disable=redefined-outer-name
+import numpy as np
+import pytest
+import buzzard as buzz
+
+S = 2 ** 14
+
+def strigify(fp):
+    return '{:<25} {!s:<45} {:<25} tl:{!s:<35} tr:{!s:<35} br:{!s:<35} bl:{!s:<35} {} {}'.format(
+        fp.angle,
+        fp.scale.tolist(),
+        np.divide.reduce(fp.scale),
+        fp.tl,
+        fp.tr,
+        fp.br,
+        fp.bl,
+        str(fp.aff6).replace('\n', ''),
+        fp.rsize,
+    )
+
+def pytest_generate_tests(metafunc):
+    with buzz.Env(allow_complex_footprint=1, significant=10):
+        fp0 = buzz.Footprint(rsize=(S, S), size=(S, S), tl=(50000, 50000))
+        transfos = [
+            (fp0,
+             fp0,
+             'identity',
+            ),
+            (fp0,
+             buzz.Footprint(rsize=(S, S), size=(S * 2, S * 2), tl=(50000, 50000)),
+             'double unit',
+            ),
+            (fp0,
+             buzz.Footprint(rsize=(S, S), gt=(50000, 1, 0, 50000, 0, -2)),
+             'double y unit',
+            ),
+            (fp0,
+             fp0.intersection(fp0, rotation=45).clip(0, 0, S, S),
+             'rotation 45',
+            ),
+            (fp0,
+             buzz.Footprint(rsize=(S, S), size=(S * 2, S * 2), tl=(50000, 50000)).intersection(fp0.dilate(S), rotation=45).clip(0, 0, S, S),
+             'rotation 45 and double unit'
+            ),
+            (fp0,
+             buzz.Footprint(rsize=(S, S), gt=(50000, 1, 0, 50000, 0, -2)).intersection(fp0.dilate(S), rotation=45).clip(0, 0, S, S),
+             'rotation 45 and double y unit'
+            ),
+            (fp0,
+             buzz.Footprint(rsize=(S, S), gt=(50000, 1, 0, 50000, 0, 1)),
+             'mirror',
+            ),
+        ]
+
+    tests = []
+    for src_fp, trg_fp, transfo_name in transfos:
+        assert np.all(src_fp.rsize == trg_fp.rsize), (src_fp.rsize, trg_fp.rsize)
+
+        for scalex in [1, -1]:
+            for scaley in [1, -1]:
+                for rot in [0, 45, -45, 90, -90, -135, 135, 180, -180]:
+                    for noise_factor in [0, 1e-6]:
+                        tests.append((
+                            transfo_name, src_fp, trg_fp, scalex, scaley, rot, noise_factor
+                        ))
+    metafunc.parametrize(
+        argnames='transfo_name,src_fp,trg_fp,scalex,scaley,rot,noise_factor',
+        argvalues=tests,
+    )
+
+def test_move(transfo_name, src_fp, trg_fp, scalex, scaley, rot, noise_factor):
+    with buzz.Env(allow_complex_footprint=1, significant=10):
+
+        src_fp = src_fp.dilate(S).intersection(
+            src_fp.dilate(S), rotation=src_fp.angle + rot, scale=src_fp.scale * [scalex, scaley]
+        ).clip(0, 0, S, S)
+        trg_fp = trg_fp.dilate(S).intersection(
+            trg_fp.dilate(S), rotation=trg_fp.angle + rot, scale=trg_fp.scale * [scalex, scaley]
+        ).clip(0, 0, S, S)
+
+        print('// src_properties:', strigify(src_fp))
+        print('// trg_properties:', strigify(trg_fp))
+        assert np.all(src_fp.rsize == trg_fp.rsize)
+
+        print('->{} noise at {:.1e}'.format(transfo_name, noise_factor))
+        tl, tr, br = trg_fp.tl, trg_fp.tr, trg_fp.br
+        tl, tr, br = np.asarray([tl, tr, br]) + np.random.rand(3, 2) * noise_factor
+
+        out_fp0 = src_fp.move(tl, tr, br)
+        print('  without snap:   ', strigify(out_fp0))
+
+        # Assert that `Footprint.move` does no give strange results
+        assert trg_fp.almost_equals(out_fp0)
+
+        out_fp1 = src_fp.move(tl, tr, br, True)
+        print('  with snap:      ', strigify(out_fp1))
+
+        # Assert that `new function` does no give strange results
+        assert trg_fp.almost_equals(out_fp1)
+
+        if src_fp.angle == trg_fp.angle and np.isclose(0, (src_fp.angle + 360) % 90):
+            # Assert that angles are be fully preserved when rotation if a multiple of 90
+            assert out_fp1.angle == src_fp.angle

--- a/buzzard/test/tools.py
+++ b/buzzard/test/tools.py
@@ -68,18 +68,23 @@ def fpeq(*items, **kwargs):
 
 def sreq(*items, verbose_on=None):
     """SR items are all equal"""
+    v = tuple(map(int, gdal.__version__.split('.')))
     for a, b in itertools.combinations(items, 2):
         a = osr.SpatialReference(osr.GetUserInputAsWKT(a))
-        a.StripCTParms()
+        if v < (3,):
+            a.StripCTParms()
         a = a.ExportToProj4()
         a = osr.SpatialReference(osr.GetUserInputAsWKT(a))
-        a.StripCTParms()
+        if v < (3,):
+            a.StripCTParms()
 
         b = osr.SpatialReference(osr.GetUserInputAsWKT(b))
-        b.StripCTParms()
+        if v < (3,):
+            b.StripCTParms()
         b = b.ExportToProj4()
         b = osr.SpatialReference(osr.GetUserInputAsWKT(b))
-        b.StripCTParms()
+        if v < (3,):
+            b.StripCTParms()
 
         res = bool(a.IsSame(b))
         if res is verbose_on:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ classifiers = [
 
 setup(
     name='buzzard',
-    version='0.6.0',
+    version='0.6.1',
     author='ngoguey',
     author_email='nicolas.goguey@delair.aero',
     license='Apache License 2.0',
@@ -62,7 +62,7 @@ setup(
     long_description_content_type='text/markdown',
     classifiers=classifiers,
     url='https://github.com/airware/buzzard',
-    download_url='https://github.com/airware/buzzard/archive/0.6.0.tar.gz',
+    download_url='https://github.com/airware/buzzard/archive/0.6.1.tar.gz',
     keywords=['gdal gis raster shp dxf tif vector'],
     packages=find_packages(),
     install_requires=reqs,


### PR DESCRIPTION
---

### Pull request information

---

Welcome to PR number 42!!!. Don't look at the branch's name, this is the version `0.6.1`, not `6.1.0`.

As usual, please review the diffs and the release note below.

---

### Beginning of the anticipated release note for `0.6.1`

---

# Public changes
### Footprint coordinates rounding after reprojection
Thanks to the new parameter of the `Footprint.move` method, opening a raster when using an `sr_work` in the `Dataset` constructor work much better than before. 

### Parameters update
- Add `Footprint.move@round_coordinates`

# Private changes
- Unit tests now work with `GDAL 3.0`
- Add strong unit tests for `Footprint.move`
  