### PR TITLE
Changed np.asscalar for ndarray.item()

### DIFF
--- a/buzzard/_actors/cached/file_checker.py
+++ b/buzzard/_actors/cached/file_checker.py
@@ -135,7 +135,7 @@ def _checksum(fname, buffer_size=512 * 1024, dtype='uint64'):
                     tail = chunk[-tailsize:] + b'\0' * (dtypesize - tailsize)
                     tail = np.frombuffer(tail, dtype)
                     acc += tail
-        return '{:016x}'.format(np.asscalar(acc))
+        return '{:016x}'.format(acc.item())
 
 def _cache_file_check(cache_fp, path, channel_count, dtype, back_ds_opt):
     checksum = path

--- a/buzzard/_actors/cached/writer.py
+++ b/buzzard/_actors/cached/writer.py
@@ -144,7 +144,7 @@ def _checksum(fname, buffer_size=512 * 1024, dtype='uint64'):
                     tail = chunk[-tailsize:] + b'\0' * (dtypesize - tailsize)
                     tail = np.frombuffer(tail, dtype)
                     acc += tail
-        return '{:016x}'.format(np.asscalar(acc))
+        return '{:016x}'.format(acc.item())
 
 def _cache_file_write(array,
                       dir_path, filename_prefix, filename_suffix,

--- a/buzzard/_tools/parameters.py
+++ b/buzzard/_tools/parameters.py
@@ -158,7 +158,7 @@ def sanitize_channels_schema(channels_schema, channel_count):
             'nodata',
             channels_schema['nodata'],
             lambda x: np.all(np.isreal(x)) and np.shape(x) == (),
-            lambda x: float(np.asscalar(np.asarray(x))),
+            lambda x: float(np.asarray(x).item()),
             None,
         ))
 
@@ -176,7 +176,7 @@ def sanitize_channels_schema(channels_schema, channel_count):
             'offset',
             channels_schema['offset'],
             lambda x: np.all(np.isreal(x)) and np.shape(x) == (),
-            lambda x: float(np.asscalar(np.asarray(x))),
+            lambda x: float(np.asarray(x).item()),
             0.,
         ))
 
@@ -185,7 +185,7 @@ def sanitize_channels_schema(channels_schema, channel_count):
             'scale',
             channels_schema['scale'],
             lambda x: np.all(np.isreal(x)) and np.shape(x) == (),
-            lambda x: float(np.asscalar(np.asarray(x))),
+            lambda x: float(np.asarray(x).item()),
             1.,
         ))
 


### PR DESCRIPTION
Numpy 1.16 introduced new "breaking" deprecation warnings :
> The numpy.asscalar function is deprecated. It is an alias to the more powerful numpy.ndarray.item, not tested, and fails for scalars.
(see https://docs.scipy.org/doc/numpy/release.html?highlight=histogram#new-deprecations)

Tests are correct.
Continuity of behaviour has been tested through: 
```python
import numpy as np

dtypes = [
    'float',
    'float128',
    'float16',
    'float32',
    'float64',
    'float_',
    'bool',
    'bool8',
    'bool_',
    'byte',
    'bytes0',
    'bytes_',
    'cdouble',
    'cfloat',
    'clongdouble',
    'clongfloat',
    'complex',
    'complex128',
    'complex256',
    'complex64',
    'complex_',
    'double',
    'int',
    'int0',
    'int16',
    'int32',
    'int64',
    'int8',
    'int_',
    'long',
    'longcomplex',
    'longdouble',
    'longfloat',
    'longlong',
    'uint0',
    'uint16',
    'uint32',
    'uint64',
    'uint8',
    'uintc',
    'uintp',
    'ulonglong',
]

values = [
    1,
    np.inf,
    np.Inf,
    np.nan,
    np.NAN,
    np.NaN,
    np.PINF,
    np.NINF,
    np.PZERO,
    np.NZERO
]
values += [np.random.rand() * 10 ** i for i in range(-100, 100, 1)]

shapes = []
shapes.append(lambda x, d: np.asarray([], dtype=d))
shapes.append(lambda x, d: np.asarray(x, dtype=d))
shapes.append(lambda x, d: np.asarray([x], dtype=d))
shapes.append(lambda x, d: np.asarray([[x]], dtype=d))
shapes.append(lambda x, d: np.asarray([[[x]]], dtype=d))
shapes.append(lambda x, d: np.asarray([x, x], dtype=d))
shapes.append(lambda x, d: np.asarray([[x, x]], dtype=d))
shapes.append(lambda x, d: np.asarray([[x], [x]], dtype=d))

res_asscalar = []
for value in values:
    for shape in shapes:
        for dtype in dtypes:
            try:
                arr = shape(value, dtype)
            except Exception as e:
                print(e)
                continue
            try:
                w = np.asscalar(arr)
                res_asscalar.append(w)
            except Exception as w:
                res_asscalar.append(w)

res_item = []
for value in values:
    for shape in shapes:
        for dtype in dtypes:
            try:
                arr = shape(value, dtype)
            except Exception as e:
                print(e)
                continue
            try:
                w = arr.item()
                res_item.append(w)
            except Exception as w:
                res_item.append(w)

for a, b in zip(res_asscalar, res_item):
    print(a)
    assert type(a) ==  type(b), f'{a} vs {b} / {type(a)} vs {type(b)}'
    assert str(a) == str(b), f'{a} vs {b} / {type(a)} vs {type(b)}'
    if not isinstance(a, Exception) and not isinstance(b, Exception):
        if not (isinstance(a, bytes) or isinstance(b, bytes)):
            if np.isnan(a) or np.isnan(b):
                assert np.isnan(b) and np.isnan(a)
                continue
        assert a == b, f'{a} vs {b} / {type(a)} vs {type(b)}'
```